### PR TITLE
Remove thunk from createFormAction

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,16 +57,14 @@ function createFormAction(requestAction, types) {
     throw new Error('Must include two action types: [ SUCCESS, FAILURE ]');
   }
 
-  return Object.assign(function (data) {
-    return function (dispatch) {
-      return new Promise(function (resolve, reject) {
-        dispatch(formAction({
-          request: requestAction(data),
-          defer: { resolve: resolve, reject: reject },
-          types: types
-        }));
-      });
-    };
+  return Object.assign(function (data, dispatch) {
+    return new Promise(function (resolve, reject) {
+      dispatch(formAction({
+        request: requestAction(data),
+        defer: { resolve: resolve, reject: reject },
+        types: types
+      }));
+    });
   }, actionMethods);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,16 +38,14 @@ function createFormAction (requestAction, types, payloadCreator = identity) {
     throw new Error('Must include two action types: [ SUCCESS, FAILURE ]');
   }
 
-  return Object.assign(data => {
-    return dispatch => {
-      return new Promise((resolve, reject) => {
-        dispatch(formAction({
-          request: requestAction(data),
-          defer: { resolve, reject },
-          types
-        }));
-      });
-    };
+  return Object.assign((data, dispatch) => {
+    return new Promise((resolve, reject) => {
+      dispatch(formAction({
+        request: requestAction(data),
+        defer: { resolve, reject },
+        types
+      }));
+    });
   }, actionMethods);
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -10,12 +10,11 @@ const FAILURE = `${PREFIX}_FAILURE`;
 
 describe('redux-form-saga', () => {
   describe('createFormAction', () => {
-    let formAction, action, dispatch, payload, thunk, promise, payloadCreator;
+    let formAction, action, dispatch, payload, promise, payloadCreator;
     let beforeFn = () => {
       dispatch = (a) => { action = a };
       payload = { mock: 'payload' };
-      thunk = formAction(payload);
-      promise = thunk(dispatch);
+      promise = formAction(payload, dispatch);
       payloadCreator = key => ({ key });
     };
 
@@ -33,11 +32,6 @@ describe('redux-form-saga', () => {
           }
           beforeFn();
         })
-
-        it('should create a thunkd action', () => {
-          expect(formAction).to.be.a('function');
-          expect(formAction({})).to.be.a('function');
-        });
 
         it('should dispatch an action with the correct structure', () => {
           expect(action.payload).to.have.keys(['defer', 'request', 'types']);


### PR DESCRIPTION
The code examples from the README don't work for me because `dispatch` is never
called. With this change, the parameters of the function returned by
`createFormAction` match the arguments given to it in redux-forms
`handleSubmit`