### PR TITLE
Easiest way to manage errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "redux-form-saga",
-  "version": "0.0.8",
+  "name": "redux-form-saga-v6",
+  "version": "0.0.9",
   "description": "An action creator and saga for integrating Redux Form and Redux Saga",
   "keywords": [
     "redux-form",
@@ -31,7 +31,7 @@
     "react-dom": "^15.3.1",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
-    "redux-form": "^5.2.5",
+    "redux-form": "^6.2.0",
     "redux-saga": "^0.10.5"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import { takeEvery } from 'redux-saga';
 import { take, race, put, call } from 'redux-saga/effects';
+import { SubmissionError } from 'redux-form';
 
 const identity = i => i;
 const PROMISE = '@@redux-form-saga/PROMISE';
@@ -66,7 +67,7 @@ function *handlePromiseSaga({ payload }) {
   if (winner.success) {
     yield call(resolve, winner.success && winner.success.payload ? winner.success.payload : winner.success);
   } else {
-    yield call(reject, winner.fail && winner.fail.payload ? winner.fail.payload : winner.fail);
+    yield call(reject, winner.fail && winner.fail.payload ? new SubmissionError(winner.fail.payload) : winner.fail);
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -4,16 +4,12 @@ import { takeEvery } from 'redux-saga';
 import { take, race, put, call } from 'redux-saga/effects';
 import { expect } from 'chai';
 import { isFSA } from 'flux-standard-action';
+import { SubmissionError } from 'redux-form';
 
 const PREFIX = 'PREFIX';
 const REQUEST = `${PREFIX}_REQUEST`;
 const SUCCESS = `${PREFIX}_SUCCESS`;
 const FAILURE = `${PREFIX}_FAILURE`;
-class SubmissionError {
-  constructor(errors) {
-    this.error = errors;
-  }
-}
 
 describe('redux-form-saga', () => {
   describe('createFormAction', () => {
@@ -126,7 +122,7 @@ describe('redux-form-saga', () => {
 
       describe('with a failed run', () => {
         it('should yield with a TAKE of type FAILURE', () => {
-          run({ fail: { payload: 'A failure!' } });
+          run({ fail: { payload: { _error: 'A failure!' } } });
         });
 
         it('should call the promise reject method with a submission ' +
@@ -134,7 +130,7 @@ describe('redux-form-saga', () => {
           const winner = {
             fail: {
               type: FAILURE,
-              payload: new SubmissionError({ _error: 'A failure!' })
+              payload: { _error: 'A failure!' }
             }
           };
 
@@ -162,7 +158,7 @@ describe('redux-form-saga', () => {
           );
         } else {
           expect(iterator.next([winner]).value).to.deep.equal(
-            call(defer.reject, winner.fail.payload)
+            call(defer.reject, new SubmissionError(winner.fail.payload))
           );
         }
       }


### PR DESCRIPTION
Hello,

I propose this little pull request because I find really hard to understand how the errors management work with redux-form-saga and redux-from 6.2 without reading the code. 

With this modification, the rejected promise return a new SubmissionError (http://redux-form.com/6.2.1/docs/api/SubmissionError.md/) if there is a payload to follow the redux-form doc.

Hope this will be helpfull.
Thanks