### PR TITLE
Upgrade takeEvery usage for redux-saga >= 0.14 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-form-saga",
-  "version": "0.0.8",
+  "version": "0.1.0",
   "description": "An action creator and saga for integrating Redux Form and Redux Saga",
   "keywords": [
     "redux-form",
@@ -32,10 +32,10 @@
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "redux-form": "^5.2.5",
-    "redux-saga": "^0.10.5"
+    "redux-saga": "^0.14.2"
   },
   "peerDependencies": {
-    "redux-saga": "*",
+    "redux-saga": ">= 0.14.2 < 1",
     "redux-form": "*"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import { takeEvery } from 'redux-saga';
-import { take, race, put, call } from 'redux-saga/effects';
+import { take, takeEvery, race, put, call } from 'redux-saga/effects';
 
 const identity = i => i;
 const PROMISE = '@@redux-form-saga/PROMISE';
@@ -71,7 +70,7 @@ function *handlePromiseSaga({ payload }) {
 }
 
 function *formActionSaga() {
-  yield call(takeEvery, PROMISE, handlePromiseSaga);
+  yield takeEvery(PROMISE, handlePromiseSaga);
 }
 
 export {

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 import 'babel-polyfill';
 import { PROMISE, createFormAction, formActionSaga, handlePromiseSaga } from '../lib';
-import { takeEvery } from 'redux-saga';
-import { take, race, put, call } from 'redux-saga/effects';
+import { take, takeEvery, race, put, call } from 'redux-saga/effects';
 import { expect } from 'chai';
 import { isFSA } from 'flux-standard-action';
 
@@ -103,11 +102,11 @@ describe('redux-form-saga', () => {
       };
     });
 
-    it('should take every PROMISE action and run handlePromise iterator', function () {
+    it('should take every PROMISE action and run the handlePromise iterator', function () {
       const iterator = formActionSaga();
 
       expect(iterator.next().value).to.deep.equal(
-        call(takeEvery, PROMISE, handlePromiseSaga)
+        takeEvery(PROMISE, handlePromiseSaga)
       );
 
       expect(iterator.next().done).to.be.true;


### PR DESCRIPTION
In redux-saga 0.14 the preferred way of using `takeEvery` changed so that there's now an effect for it. This patch silences the deprecation warning and adds some version parameters to help guard against incompatible combinations going forward.