### PR TITLE
Add module property to package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 .idea
 .DS_Store
 node_modules
-src/
 example/
 tests/
 test/

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "submit"
   ],
   "main": "lib/index.js",
+  "module": "src/index.js",
   "devDependencies": {
     "babel-cli": "^6.4.5",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Was running into an issue where the redux-form-saga dist required "regeneratorRuntime" but my webpack build was not producing it based on the browser matrix I provided to babel-preset-env.

https://github.com/webpack/webpack/issues/1979#issuecomment-273789240