### PR TITLE
Fix redux-saga deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2339,14 +2339,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2355,6 +2347,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3436,9 +3436,9 @@
       }
     },
     "redux-saga": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.14.8.tgz",
-      "integrity": "sha1-rQGvq+AuxBoX31Ti4JqiNrMKdzI=",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.15.6.tgz",
+      "integrity": "sha1-hjjcUi3mxsCklv6LK1RmKHrC3E0=",
       "dev": true
     },
     "regenerate": {
@@ -3666,15 +3666,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3684,6 +3675,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "flux-standard-action": "^0.6.0",
     "mocha": "^2.3.4",
     "react": "^15.3.1",
-    "redux-saga": "^0.14.2"
+    "redux-saga": "^0.15.5"
   },
   "peerDependencies": {
     "redux-saga": ">= 0.14.2 < 1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { take, takeEvery, race, put, call } from 'redux-saga/effects';
+import { take, takeEvery, race, put, call, all } from 'redux-saga/effects';
 
 const identity = i => i;
 const PROMISE = '@@redux-form-saga/PROMISE';
@@ -54,13 +54,13 @@ function *handlePromiseSaga({ payload }) {
   const { resolve, reject } = defer;
   const [ SUCCESS, FAIL ] = types;
 
-  const [ winner ] = yield [
+  const [ winner ] = yield all([
     race({
       success: take(SUCCESS),
       fail: take(FAIL),
     }),
     put(request),
-  ];
+  ]);
 
   if (winner.success) {
     yield call(resolve, winner.success && winner.success.payload ? winner.success.payload : winner.success);

--- a/test/test.js
+++ b/test/test.js
@@ -137,7 +137,7 @@ describe('redux-form-saga', () => {
             }
           };
 
-          expect(iterator.next().value).to.deep.equal([
+          expect(iterator.next().value.ALL).to.deep.equal([
             race({ success: take(SUCCESS), fail: take(FAILURE) }),
             put(request),
           ]);
@@ -150,7 +150,7 @@ describe('redux-form-saga', () => {
 
 
       function run(winner) {
-        expect(iterator.next().value).to.deep.equal([
+        expect(iterator.next().value.ALL).to.deep.equal([
           race({ success: take(SUCCESS), fail: take(FAILURE) }),
           put(request),
         ]);


### PR DESCRIPTION
I've updated redux-saga in my project to 0.15.5 and got deprecation warning
```
[...effects] has been deprecated in favor of all([...effects]), please update your code 
```

So I think I fixed a place that caused it and also updated some deps and tests.