### PR TITLE
Create a setTypes func to override default status

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,11 @@ import { take, takeEvery, race, put, call } from 'redux-saga/effects';
 
 const identity = i => i;
 const PROMISE = '@@redux-form-saga/PROMISE';
-const status = ['REQUEST', 'SUCCESS', 'FAILURE'];
+let status = ['REQUEST', 'SUCCESS', 'FAILURE'];
+
+function setTypes(statusOverride) {
+ status = statusOverride 
+}
 
 function createFormAction (requestAction, types, payloadCreator = identity) {
   const actionMethods = {};
@@ -78,6 +82,7 @@ export {
   createFormAction,
   formActionSaga,
   handlePromiseSaga,
+  setTypes,
 }
 
 export default formActionSaga;


### PR DESCRIPTION
The `setTypes` function allows the user to override the default status.

For instance in my case, I don't use "FAILURE" but "ERROR".  
With this PR, I could do the following:

```
import { setTypes, createFormAction } from 'redux-form-saga';

setTypes(["REQUEST", "SUCCESS", "ERROR"]);

const login = createFormAction("account/LOGIN");
```